### PR TITLE
jQuery 1.3.2 support. Issue #288

### DIFF
--- a/src/jquery.daterangepicker.js
+++ b/src/jquery.daterangepicker.js
@@ -927,13 +927,6 @@
 
 			box = createDom().hide();
 			box.append('<div class="date-range-length-tip"></div>');
-			box.delegate('.day', 'mouseleave', function()
-			{
-				box.find('.date-range-length-tip').hide();
-				if (opt.singleDate) {
-				    clearHovering();
-				}
-			});
 
 			$(opt.container).append(box);
 
@@ -1067,21 +1060,6 @@
 				showMonth(prevMonth1, 'month1');
 				showSelectedDays();
 			}
-
-			box.delegate('.day','click', function(evt)
-			{
-				dayClicked($(this));
-			});
-
-			box.delegate('.day','mouseenter',function(evt)
-			{
-				dayHovering($(this));
-			});
-
-			box.delegate('.week-number', 'click', function(evt)
-			{
-				weekNumberClicked($(this));
-			});
 
 			box.attr('unselectable', 'on')
 			.css('user-select', 'none')
@@ -1999,6 +1977,29 @@
 			box.find('.'+month+' tbody').html(createMonthHTML(date));
 			opt[month] = date;
 			updateSelectableRange();
+			bindDayEvents();
+		}
+		
+		function bindDayEvents()
+		{
+		    box.find('.day').unbind("click").click(function (evt) {
+			dayClicked($(this));
+		    });
+
+		    box.find('.day').unbind("mouseenter").mouseenter(function (evt) {
+			dayHovering($(this));
+		    });
+
+		    box.find('.day').unbind("mouseleave").mouseleave(function (evt) {
+			box.find('.date-range-length-tip').hide();
+			if (opt.singleDate) {
+			    clearHovering();
+			}
+		    });
+
+		    box.find('.week-number').unbind("click").click(function (evt) {
+			weekNumberClicked($(this));
+		    });
 		}
 
 		function showTime(date,name)


### PR DESCRIPTION
Moved events binding for days and week number elements to showMonth() function - the place where the elements are added to the DOM.
This code tested and works with jquery-1.3.2 and jquery-1.12.2.
